### PR TITLE
Add tests to unity-ci configuration

### DIFF
--- a/.github/workflows/unity-ci.yaml
+++ b/.github/workflows/unity-ci.yaml
@@ -24,6 +24,23 @@ jobs:
           key: Library-${{ hashFiles('src/FruityTech-Studio/Assets/**', 'src/FruityTech-Studio/Packages/**', 'src/FruityTech-Studio/ProjectSettings/**') }}
           restore-keys: Library-
 
+      - name: Validate Unity license input
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -z "${{ secrets.UNITY_LICENSE }}" && ( -z "${{ secrets.UNITY_EMAIL }}" || -z "${{ secrets.UNITY_PASSWORD }}" ) ]]; then
+            echo "Missing Unity licensing secrets. Provide UNITY_LICENSE, or UNITY_EMAIL + UNITY_PASSWORD."
+            exit 1
+          fi
+
+      - name: Prepare Unity writable directories
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p .ci-home/.local/share/unity3d
+          mkdir -p .ci-home/.cache/unity3d
+          mkdir -p .ci-home/.config/unity3d
+
       - name: Patch GameCI script BOM
         shell: bash
         run: |
@@ -39,6 +56,9 @@ jobs:
       - name: Run Tests
         uses: game-ci/unity-test-runner@v4
         env:
+          HOME: /github/workspace/.ci-home
+          XDG_CONFIG_HOME: /github/workspace/.ci-home/.config
+          XDG_CACHE_HOME: /github/workspace/.ci-home/.cache
           UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
           UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
           UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
@@ -73,6 +93,23 @@ jobs:
           key: Library-${{ hashFiles('src/FruityTech-Studio/Assets/**', 'src/FruityTech-Studio/Packages/**', 'src/FruityTech-Studio/ProjectSettings/**') }}
           restore-keys: Library-
 
+      - name: Validate Unity license input
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -z "${{ secrets.UNITY_LICENSE }}" && ( -z "${{ secrets.UNITY_EMAIL }}" || -z "${{ secrets.UNITY_PASSWORD }}" ) ]]; then
+            echo "Missing Unity licensing secrets. Provide UNITY_LICENSE, or UNITY_EMAIL + UNITY_PASSWORD."
+            exit 1
+          fi
+
+      - name: Prepare Unity writable directories
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p .ci-home/.local/share/unity3d
+          mkdir -p .ci-home/.cache/unity3d
+          mkdir -p .ci-home/.config/unity3d
+
       - name: Patch GameCI script BOM
         shell: bash
         run: |
@@ -98,6 +135,9 @@ jobs:
       - name: Build
         uses: game-ci/unity-builder@v4
         env:
+          HOME: /github/workspace/.ci-home
+          XDG_CONFIG_HOME: /github/workspace/.ci-home/.config
+          XDG_CACHE_HOME: /github/workspace/.ci-home/.cache
           UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
           UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
           UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}


### PR DESCRIPTION
This pull request updates the Unity CI workflow in `.github/workflows/unity-ci.yaml` to improve reliability and security when running Unity builds and tests in GitHub Actions. The main changes focus on validating Unity licensing secrets and ensuring Unity has the necessary writable directories in the CI environment.

**Unity licensing and environment setup:**

* Added a step to validate Unity license input, ensuring that either `UNITY_LICENSE` or both `UNITY_EMAIL` and `UNITY_PASSWORD` secrets are present before proceeding. This prevents CI failures due to missing credentials. [[1]](diffhunk://#diff-9da0346dafff9a9a1af7c64d82af6173519678d2e198afedc2dd35b417c35fd7R27-R43) [[2]](diffhunk://#diff-9da0346dafff9a9a1af7c64d82af6173519678d2e198afedc2dd35b417c35fd7R96-R112)
* Added a step to prepare writable directories for Unity under `.ci-home`, creating required folders for Unity's configuration, cache, and local data. This helps avoid permission issues during CI runs. [[1]](diffhunk://#diff-9da0346dafff9a9a1af7c64d82af6173519678d2e198afedc2dd35b417c35fd7R27-R43) [[2]](diffhunk://#diff-9da0346dafff9a9a1af7c64d82af6173519678d2e198afedc2dd35b417c35fd7R96-R112)

**Environment variable configuration:**

* Updated the environment variables for both the test runner and build steps to set `HOME`, `XDG_CONFIG_HOME`, and `XDG_CACHE_HOME` to the new `.ci-home` paths, ensuring Unity uses the prepared writable directories. [[1]](diffhunk://#diff-9da0346dafff9a9a1af7c64d82af6173519678d2e198afedc2dd35b417c35fd7R59-R61) [[2]](diffhunk://#diff-9da0346dafff9a9a1af7c64d82af6173519678d2e198afedc2dd35b417c35fd7R138-R140)